### PR TITLE
Fix typo in referenced Unique Headers class name.

### DIFF
--- a/unique-headers-single-posts.php
+++ b/unique-headers-single-posts.php
@@ -61,7 +61,7 @@ class Single_Post_Header_Images {
 	 */
 	public function init() {
 
-		if ( ! class_exists( 'Unique_Header_Taxonomy_Header_Images' ) ) {
+		if ( ! class_exists( 'Unique_Headers_Taxonomy_Header_Images' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The 2017 update of Unique Headers changed the name of the "Unique_Headers_Taxonomy_Header_Image" class that is referenced in the Single Post plugin extension. 
I fixed that reference in the plugin extension.